### PR TITLE
Git name

### DIFF
--- a/lib/ors/config.rb
+++ b/lib/ors/config.rb
@@ -58,7 +58,7 @@ module ORS
       private
 
       def name_from_git
-        git.config["remote.origin.url"].gsub(/^[\w]*(@|:\/\/)[^\/:]*(\/|:)([a-zA-Z0-9\/]*)(.git)?$/i, '\3')
+        git.config["remote.origin.url"].gsub(/^[\w]*(@|:\/\/)[^\/:]*(\/|:)([a-zA-Z0-9\/_-]*)(.git)?$/i, '\3')
       end
 
     end

--- a/spec/ors/config_spec.rb
+++ b/spec/ors/config_spec.rb
@@ -105,7 +105,9 @@ describe ORS::Config do
      "git@github.com:testing/github" => "testing/github",
      "git@ghub.com:testing/gitlabhq.git" => "testing/gitlabhq",
      "git@ghub.com:gitlabhq.git" => "gitlabhq",
-     "git://ghub.com/gitlabhq.git" => "gitlabhq"
+     "git://ghub.com/gitlabhq.git" => "gitlabhq",
+     "git://ghub.com/level_git.git" => "level_git",
+     "git://ghub.com/level-up/two.git" => "level-up/two"
     }.each do |remote, name|
       it "should handle a remote origin url such as #{remote}" do
         mock(ORS::Config).git { mock!.config { {"remote.origin.url" => remote} }}


### PR DESCRIPTION
I forgot to add underscores and hyphens for possible git repo names... I should probably check the valid character range..but I'm lazy and this works for all repos we have now.  :)
