### PR TITLE
Allow the '.' character in repo names

### DIFF
--- a/lib/ors/config.rb
+++ b/lib/ors/config.rb
@@ -104,7 +104,7 @@ class ORS
     end
 
     def name
-      remote_url.gsub(/^[\w]*(@|:\/\/)[^\/:]*(\/|:)([a-zA-Z0-9\/_\-]*)(.git)?$/i, '\3')
+      remote_url.gsub(/^[\w]*(@|:\/\/)[^\/:]*(\/|:)([\w\.\/_\-]+)$/, '\3').gsub(/\.git$/i, '')
     end
 
     def deploy_directory

--- a/spec/ors/config_spec.rb
+++ b/spec/ors/config_spec.rb
@@ -75,7 +75,8 @@ describe ORS::Config do
      "git@ghub.com:gitlabhq.git" => "gitlabhq",
      "git://ghub.com/gitlabhq.git" => "gitlabhq",
      "git://ghub.com/level_git.git" => "level_git",
-     "git://ghub.com/level-up/two.git" => "level-up/two"
+     "git://ghub.com/level-up/two.git" => "level-up/two",
+     "git@mygitrepo:mywebsite.com/someapp" => "mywebsite.com/someapp"
     }.each do |remote, name|
       it "should handle a remote origin url such as #{remote}" do
         stub(subject).git { mock!.config { {"remote.origin.url" => remote} }}


### PR DESCRIPTION
Just what it says on the tin.
